### PR TITLE
Make everyone bash users

### DIFF
--- a/ansible/roles/sequoia_fabrica/tasks/users.yml
+++ b/ansible/roles/sequoia_fabrica/tasks/users.yml
@@ -8,6 +8,7 @@
       - sudo
       - docker
     append: true
+    shell: /bin/bash
 
 - name: "Sequoia Fabrica group: passwordless sudo"
   become: true
@@ -28,6 +29,7 @@
       - sequoia.fabrica
     append: true
     state: present
+    shell: /bin/bash
   with_items:
     - "{{ sequoia_fabrica_users }}"
 


### PR DESCRIPTION
This is just nicety so the default shell isn't sh. Gives ssh users a little more to work with